### PR TITLE
Add plugin events

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: StatsPE
-version: 3.4.0
+version: 3.4.1
 api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 main: SalmonDE\StatsPE\Base
 description: Playerstatistics for your server!

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: StatsPE
-version: 3.3.4
+version: 3.4.0
 api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 main: SalmonDE\StatsPE\Base
 description: Playerstatistics for your server!

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -37,5 +37,3 @@ MySQL:
     username: "ExampleUser"
     password: "123456789"
     database: "StatsPE"
-# Enables self updating of the plugin
-Auto-Update: true

--- a/src/SalmonDE/StatsPE/Base.php
+++ b/src/SalmonDE/StatsPE/Base.php
@@ -87,6 +87,8 @@ class Base extends \pocketmine\plugin\PluginBase
         $this->provider->addEntry(new Entry('Username', 'undefined', Entry::STRING, true));
         foreach($this->getConfig()->get('Stats') as $statistic => $enabled){
             if($enabled){
+                $unsigned = false;
+
                 switch($statistic){
                     case 'Online':
                         $default = false;
@@ -122,6 +124,7 @@ class Base extends \pocketmine\plugin\PluginBase
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'FirstJoin':
@@ -146,56 +149,65 @@ class Base extends \pocketmine\plugin\PluginBase
                         $default = 1;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'KillCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'DeathCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'BlockBreakCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'BlockPlaceCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'ChatCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'ItemConsumeCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'ItemCraftCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                         break;
 
                     case 'ItemDropCount':
                         $default = 0;
                         $expectedType = Entry::INT;
                         $save = true;
+                        $unsigned = true;
                 }
-                $this->provider->addEntry(new Entry($statistic, $default, $expectedType, $save));
+                $this->provider->addEntry(new Entry($statistic, $default, $expectedType, $save, $unsigned));
             }
         }
         if($this->getDataProvider()->entryExists('K/D')){

--- a/src/SalmonDE/StatsPE/Base.php
+++ b/src/SalmonDE/StatsPE/Base.php
@@ -24,7 +24,7 @@ class Base extends \pocketmine\plugin\PluginBase
         $this->saveResource('messages.yml');
         $this->initializeProvider();
         if($this->isEnabled()){
-            $this->runUpdateManager();
+            $updateManager = new \SalmonDE\Updater\UpdateManager($this);
 
             if(!file_exists($this->getDataFolder().'messages.yml')){
                 if($this->getResource($lang = ($this->getConfig()->get('Language').'.yml')) === null){
@@ -237,9 +237,5 @@ class Base extends \pocketmine\plugin\PluginBase
             $message = $message[$k];
         }
         return $message;
-    }
-
-    public function runUpdateManager(){
-        \SalmonDE\Updater\UpdateManager::getNew($this->getFile(), $this, $this->getConfig()->get('Auto-Update'))->start();
     }
 }

--- a/src/SalmonDE/StatsPE/EventListener.php
+++ b/src/SalmonDE/StatsPE/EventListener.php
@@ -2,9 +2,16 @@
 namespace SalmonDE\StatsPE;
 
 use pocketmine\Player;
+use SalmonDE\StatsPE\Events\EntryEvent;
 
 class EventListener implements \pocketmine\event\Listener
 {
+
+    public function onEntryEvent(EntryEvent $event){
+        if($event->getType() === EntryEvent::REMOVE && $event->getEntry()->getName() === 'Username'){
+            $event->setCancelled();
+        }
+    }
 
     public function onJoin(\pocketmine\event\player\PlayerJoinEvent $event){
         if(!is_array($data = Base::getInstance()->getDataProvider()->getAllData($event->getPlayer()->getName()))){

--- a/src/SalmonDE/StatsPE/EventListener.php
+++ b/src/SalmonDE/StatsPE/EventListener.php
@@ -134,7 +134,7 @@ class EventListener implements \pocketmine\event\Listener
     public function onCraftItem(\pocketmine\event\inventory\CraftItemEvent $event){
         if(!$event->isCancelled()){
             if(Base::getInstance()->getDataProvider()->entryExists('ItemCraftCount')){
-                Base::getInstance()->getDataProvider()->incrementValue($name = $event->getPlayer()->getName(), $ent = Base::getInstance()->getDataProvider()->getEntry('ItemCraftCount'), Base::getInstance()->getDataProvider()->getData($name, $ent) + 1);
+                Base::getInstance()->getDataProvider()->incrementValue($event->getPlayer()->getName(), Base::getInstance()->getDataProvider()->getEntry('ItemCraftCount'));
             }
         }
     }

--- a/src/SalmonDE/StatsPE/EventListener.php
+++ b/src/SalmonDE/StatsPE/EventListener.php
@@ -7,6 +7,9 @@ use SalmonDE\StatsPE\Events\EntryEvent;
 class EventListener implements \pocketmine\event\Listener
 {
 
+    /**
+    * @priority HIGHEST
+    */
     public function onEntryEvent(EntryEvent $event){
         if($event->getType() === EntryEvent::REMOVE && $event->getEntry()->getName() === 'Username'){
             $event->setCancelled();

--- a/src/SalmonDE/StatsPE/Events/DataEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataEvent.php
@@ -35,7 +35,7 @@ class DataEvent extends StatsPE_Event
 
     public function setData($data){
         if($this->entry === null || $this->entry->isValidType($data)){
-            $this->data = $data
+            $this->data = $data;
         }
     }
 }

--- a/src/SalmonDE/StatsPE/Events/DataEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataEvent.php
@@ -1,0 +1,41 @@
+<?php
+namespace SalmonDE\StatsPE\Events;
+
+class DataEvent extends StatsPE_Event
+{
+    /*
+    SAVE for saving data
+    RECEIVE for getting data
+    */
+
+    public static $handlerList = null;
+
+    private $player;
+    private $entry;
+    private $data;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin, $data, string $player = null, \SalmonDE\StatsPE\Providers\Entry $entry = null){
+        parent::__construct($plugin);
+        $this->player = $player;
+        $this->entry = $entry;
+        $this->data = $data;
+    }
+
+    public function getPlayerName() : string{
+        return $this->player;
+    }
+
+    public function getEntry(){
+        return $this->entry;
+    }
+
+    public function getData(){
+        return $this->data;
+    }
+
+    public function setData($data){
+        if($this->entry === null || $this->entry->isValidType($data)){
+            $this->data = $data
+        }
+    }
+}

--- a/src/SalmonDE/StatsPE/Events/DataReceiveEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataReceiveEvent.php
@@ -1,0 +1,12 @@
+<?php
+namespace SalmonDE\StatsPE\Events;
+
+class DataReceiveEvent extends StatsPE_Event
+{
+
+    public static $handlerList = null;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin, $data, string $player = null, \SalmonDE\StatsPE\Providers\Entry $entry = null){
+        parent::__construct($plugin, $data, $player, $entry);
+    }
+}

--- a/src/SalmonDE/StatsPE/Events/DataReceiveEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataReceiveEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace SalmonDE\StatsPE\Events;
 
-class DataReceiveEvent extends StatsPE_Event
+class DataReceiveEvent extends DataEvent
 {
 
     public static $handlerList = null;

--- a/src/SalmonDE/StatsPE/Events/DataSaveEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataSaveEvent.php
@@ -1,0 +1,12 @@
+<?php
+namespace SalmonDE\StatsPE\Events;
+
+class DataSaveEvent extends StatsPE_Event implements \pocketmine\event\Cancellable
+{
+
+    public static $handlerList = null;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin, $data, string $player, \SalmonDE\StatsPE\Providers\Entry $entry){
+        parent::__construct($plugin, $data, $player, $entry);
+    }
+}

--- a/src/SalmonDE/StatsPE/Events/DataSaveEvent.php
+++ b/src/SalmonDE/StatsPE/Events/DataSaveEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace SalmonDE\StatsPE\Events;
 
-class DataSaveEvent extends StatsPE_Event implements \pocketmine\event\Cancellable
+class DataSaveEvent extends DataEvent implements \pocketmine\event\Cancellable
 {
 
     public static $handlerList = null;

--- a/src/SalmonDE/StatsPE/Events/EntryEvent.php
+++ b/src/SalmonDE/StatsPE/Events/EntryEvent.php
@@ -1,0 +1,30 @@
+<?php
+namespace SalmonDE\StatsPE\Events;
+
+use SalmonDE\StatsPE\Providers\Entry;
+
+class EntryEvent extends StatsPE_Event implements \pocketmine\event\Cancellable
+{
+
+    public static $handlerList = null;
+
+    const ADD = 0;
+    const REMOVE = 1;
+
+    private $entry;
+    private $type;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin, Entry $entry, int $type){
+        parent::__construct($plugin);
+        $this->entry = $entry;
+        $this->$type = $type;
+    }
+
+    public function getEntry() : Entry{
+        return $this->entry;
+    }
+
+    public function getType() : int{
+        return $this->type;
+    }
+}

--- a/src/SalmonDE/StatsPE/Events/StatsPE_Event.php
+++ b/src/SalmonDE/StatsPE/Events/StatsPE_Event.php
@@ -1,0 +1,14 @@
+<?php
+namespace SalmonDE\StatsPE\Events;
+
+use SalmonDE\StatsPE\Providers\Entry;
+
+class StatsPE_Event extends \pocketmine\event\plugin\PluginEvent
+{
+
+    public static $handlerList = null;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin){
+        parent::__construct($plugin);
+    }
+}

--- a/src/SalmonDE/StatsPE/FloatingTexts/Events/FloatingTextEvent.php
+++ b/src/SalmonDE/StatsPE/FloatingTexts/Events/FloatingTextEvent.php
@@ -1,0 +1,31 @@
+<?php
+namespace SalmonDE\StatsPE\FloatingTexts\Events;
+
+use SalmonDE\StatsPE\FloatingTexts\FloatingText;
+
+class FloatingTextEvent extends \SalmonDE\StatsPE\Events\StatsPE_Event implements \pocketmine\event\Cancellable
+{
+
+    public static $handlerList = null;
+
+    const ADD = 0;
+    const REMOVE = 1;
+
+    private $floatingText;
+    private $type;
+
+    public function __construct(\pocketmine\plugin\Plugin $plugin, FloatingText $floatingText, int $types){
+        parent::__construct($plugin);
+        $this->floatingText = $floatingText;
+        $this->type = $type;
+    }
+
+
+    public function getFloatingText() : FloatingText{
+        return $this->floatingText;
+    }
+
+    public function getType() : int{
+        return $this->type;
+    }
+}

--- a/src/SalmonDE/StatsPE/Providers/Entry.php
+++ b/src/SalmonDE/StatsPE/Providers/Entry.php
@@ -15,8 +15,9 @@ class Entry
     private $expectedType;
     private $valid = false;
     private $shouldSave;
+    private $unsigned;
 
-    public function __construct(string $name, $default, int $type, bool $shouldSave){
+    public function __construct(string $name, $default, int $type, bool $shouldSave, $unsigned = false){
         $this->name = $name;
         $this->expectedType = $type;
         if($this->isValidType($default)){
@@ -74,6 +75,10 @@ class Entry
                 return true;
         }
         return false;
+    }
+
+    public function isUnsigned() : bool{
+        return ($this->unsigned && $this->expectedType === self::INT);
     }
 
     public function isValid() : bool{

--- a/src/SalmonDE/StatsPE/Providers/JSONProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/JSONProvider.php
@@ -61,7 +61,7 @@ class JSONProvider implements DataProvider
         if($this->entryExists($entry->getName()) && $entry->shouldSave()){
             if($entry->isValidType($value)){
 
-                $event = new \SalmonDE\StatsPE\Events\DataReceiveEvent(Base::getInstance(), $value, $player, $entry);
+                $event = new \SalmonDE\StatsPE\Events\DataSaveEvent(Base::getInstance(), $value, $player, $entry);
                 Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
                 if(!$event->isCancelled()){
                     $this->dataConfig->setNested(strtolower($player).'.'.$entry->getName(), $value);

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -45,7 +45,7 @@ class MySQLProvider implements DataProvider
         foreach($this->entries as $entry){
             if($entry->shouldSave() && $entry->getName() !== 'Username'){
                 $type = Utils::getMySQLDatatype($entry->getExpectedType());
-                $columns[] = $this->db->real_escape_string($entry->getName()).' '.$type.' NOT NULL DEFAULT '.(is_string($value = $this->db->real_escape_string(Utils::convertValueSave($entry, $entry->getDefault()))) ? "'$value'" : $value);
+                $columns[] = $this->db->real_escape_string($entry->getName()).' '.$type.' NOT NULL DEFAULT '.(is_string($value = Utils::convertValueSave($entry, $entry->getDefault())) ? "'".$this->db->real_escape_string($value)."'" : $value);
             }
         }
 

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -45,7 +45,7 @@ class MySQLProvider implements DataProvider
         foreach($this->entries as $entry){
             if($entry->shouldSave() && $entry->getName() !== 'Username'){
                 $type = Utils::getMySQLDatatype($entry->getExpectedType());
-                $columns[] = $this->db->real_escape_string($entry->getName()).' '.$type.' NOT NULL DEFAULT '.(is_string($value = Utils::convertValueSave($entry, $entry->getDefault())) ? "'".$this->db->real_escape_string($value)."'" : $value);
+                $columns[] = $this->db->real_escape_string($entry->getName()).' '.$type.($entry->isUnsigned() ? ' UNSIGNED ' : ' ').'NOT NULL DEFAULT '.(is_string($value = Utils::convertValueSave($entry, $entry->getDefault())) ? "'".$this->db->real_escape_string($value)."'" : $value);
             }
         }
 

--- a/src/SalmonDE/StatsPE/Utils.php
+++ b/src/SalmonDE/StatsPE/Utils.php
@@ -66,7 +66,7 @@ class Utils
     public static function getMySQLDatatype(int $type) : string{
         switch($type){
             case Entry::INT:
-                return 'INT(255)';
+                return 'BIGINT(255)';
 
             case Entry::FLOAT:
                 return 'DECIMAL(65, 3)';


### PR DESCRIPTION
#### **What does the PR do?**
It adds events to the plugin which makes external plugins more able to interfer with StatsPE and react to situations. 

Edit:
It also removes the auto update feature so it won't get problems with Poggit anymore.
Version checking is still implemented.

#### **Why should this PR be merged?**
There normally shouldn't be any difference in behaviour, as stated above it's mainly for other plugins which need this. 

#### **Are the changes in this PR tested**?
<!-- Please test the Pull Request yourself before submitting a pull request. -->
- [ ] Yes
- [x] Partly (JSON)
- [ ] No

#### **Extra Information**
<!-- Anything else we should know? -->
JSON was tested to the bare minimum and MySQL wasn't at all.
So MySQL needs testing, while JSON seems to be stable but could also be tested more further.