### PR TITLE
Mysql optimization

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: StatsPE
-version: 3.5.1
+version: 3.5.2
 api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 main: SalmonDE\StatsPE\Base
 description: Playerstatistics for your server!

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: StatsPE
-version: 3.4.5
+version: 3.5.0
 api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 main: SalmonDE\StatsPE\Base
 description: Playerstatistics for your server!

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,5 +1,5 @@
 name: StatsPE
-version: 3.5.0
+version: 3.5.1
 api: [3.0.0-ALPHA1, 3.0.0-ALPHA2, 3.0.0-ALPHA3, 3.0.0-ALPHA4, 3.0.0-ALPHA5]
 main: SalmonDE\StatsPE\Base
 description: Playerstatistics for your server!

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -23,14 +23,16 @@ Stats:
   ItemConsumeCount: true
   ItemCraftCount: true
   ItemDropCount: true
+
+# Date format, for a further explanation see here: http://php.net/manual/de/function.date.php
+dateFormat: "H:i:s d. M Y"
 # Data provider for StatsPE
 # It can save it's data in these providers:
 # mysql, json
 Provider: json
-# Time in minutes after which changes are saved
-Save-Interval: 20
-# Date format, for a further explanation see here: http://php.net/manual/de/function.date.php
-Date-Format: "H:i:s d. M Y"
+JSON:
+    # Time in minutes after which changes are saved
+    saveInterval: 20
 # mysql settings in case you're using it
 MySQL:
     host: "example.net:3306"

--- a/resources/config.yml
+++ b/resources/config.yml
@@ -37,3 +37,4 @@ MySQL:
     username: "ExampleUser"
     password: "123456789"
     database: "StatsPE"
+    cacheLimit: 100

--- a/src/SalmonDE/StatsPE/Base.php
+++ b/src/SalmonDE/StatsPE/Base.php
@@ -66,6 +66,10 @@ class Base extends \pocketmine\plugin\PluginBase
     }
 
     private function initializeProvider(){
+        if($this->provider instanceof Providers\DataProvider){
+            return;
+        }
+
         switch($p = $this->getConfig()->get('Provider')){
             case 'json':
                 $this->getLogger()->info('Selecting JSON data provider ...');

--- a/src/SalmonDE/StatsPE/Base.php
+++ b/src/SalmonDE/StatsPE/Base.php
@@ -43,7 +43,7 @@ class Base extends \pocketmine\plugin\PluginBase
             }
             $this->registerCommands();
 
-            if(($i = $this->getConfig()->get('Save-Interval')) >= 1){
+            if(($i = $this->getConfig()->getNested('JSON.saveInterval')) >= 1){
                 $this->getServer()->getScheduler()->scheduleDelayedRepeatingTask(new Tasks\SaveTask($this), $i *= 1200, $i);
             }else{
                 $this->getLogger()->warning('The save interval is lower than 1 min! Please make sure to always properly shutdown the server in order to prevent data loss!');

--- a/src/SalmonDE/StatsPE/Base.php
+++ b/src/SalmonDE/StatsPE/Base.php
@@ -74,7 +74,7 @@ class Base extends \pocketmine\plugin\PluginBase
 
             case 'mysql':
                 $this->getLogger()->info('Selecting MySQL data provider ...');
-                $this->provider = new Providers\MySQLProvider(($c = $this->getConfig())->getNested('MySQL.host'), $c->getNested('MySQL.username'), $c->getNested('MySQL.password'), $c->getNested('MySQL.database'));
+                $this->provider = new Providers\MySQLProvider(($c = $this->getConfig())->getNested('MySQL.host'), $c->getNested('MySQL.username'), $c->getNested('MySQL.password'), $c->getNested('MySQL.database'), $c->getNested('MySQL.cacheLimit'));
                 break;
 
             default:

--- a/src/SalmonDE/StatsPE/Commands/StatsCmd.php
+++ b/src/SalmonDE/StatsPE/Commands/StatsCmd.php
@@ -30,12 +30,12 @@ class StatsCmd extends \pocketmine\command\PluginCommand implements \pocketmine\
                     switch($entry->getName()){
                         case 'FirstJoin':
                             $p = $sender->getServer()->getOfflinePlayer($args[0]);
-                            $value = date($this->getPlugin()->getConfig()->get('Date-Format'), $p->getFirstPlayed() / 1000);
+                            $value = date($this->getPlugin()->getConfig()->get('dateFormat'), $p->getFirstPlayed() / 1000);
                             break;
 
                         case 'LastJoin':
                             $p = $sender->getServer()->getOfflinePlayer($args[0]);
-                            $value = date($this->getPlugin()->getConfig()->get('Date-Format'), $p->getLastPlayed() / 1000);
+                            $value = date($this->getPlugin()->getConfig()->get('dateFormat'), $p->getLastPlayed() / 1000);
                             break;
 
                         case 'OnlineTime':

--- a/src/SalmonDE/StatsPE/FloatingTexts/FloatingText.php
+++ b/src/SalmonDE/StatsPE/FloatingTexts/FloatingText.php
@@ -37,11 +37,11 @@ class FloatingText extends \pocketmine\level\particle\FloatingTextParticle
             if(Base::getInstance()->getDataProvider()->entryExists($key)){
                 switch($key){
                     case 'FirstJoin':
-                        $value = date(Base::getInstance()->getConfig()->get('Date-Format'), $player->getFirstPlayed() / 1000);
+                        $value = date(Base::getInstance()->getConfig()->get('dateFormat'), $player->getFirstPlayed() / 1000);
                         break;
 
                     case 'LastJoin':
-                        $value = date(Base::getInstance()->getConfig()->get('Date-Format'), $player->getLastPlayed() / 1000);
+                        $value = date(Base::getInstance()->getConfig()->get('dateFormat'), $player->getLastPlayed() / 1000);
                         break;
 
                     case 'OnlineTime':

--- a/src/SalmonDE/StatsPE/Providers/DataProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/DataProvider.php
@@ -10,6 +10,8 @@ interface DataProvider
 
     public function getData(string $player, Entry $entry);
 
+    public function getDataWhere(Entry $needleEntry, $needle, array $wantedEntries);
+
     public function getAllData(string $player = null);
 
     public function saveData(string $player, Entry $entry, $value);

--- a/src/SalmonDE/StatsPE/Providers/JSONProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/JSONProvider.php
@@ -44,7 +44,7 @@ class JSONProvider implements DataProvider
         }
     }
 
-    public function getDataWhere(Entry $needleEntry, $needle, array $wantedEntries){ // Needs testing!
+    public function getDataWhere(Entry $needleEntry, $needle, array $wantedEntries){
         if($this->entryExists($needleEntry->getName()) && $needleEntry->shouldSave()){
             if($wantedEntries === []){
                 return [];

--- a/src/SalmonDE/StatsPE/Providers/JSONProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/JSONProvider.php
@@ -44,6 +44,26 @@ class JSONProvider implements DataProvider
         }
     }
 
+    public function getDataWhere(Entry $needleEntry, $needle, array $wantedEntries){ // Needs testing!
+        if($this->entryExists($needleEntry->getName()) && $needleEntry->shouldSave()){
+            if($wantedEntries === []){
+                return [];
+            }
+
+            foreach($this->getAllData() as $player => $playerData){
+                foreach($wantedEntries as $entry){
+                    if(!$entry->shouldSave()){
+                        $resultData[$player][$entry->getName()] = null;
+                        continue;
+                    }
+
+                    $resultData[$player][$entry->getName()] = $playerData[$entry->getName()];
+                }
+            }
+            return $resultData;
+        }
+    }
+
     public function getAllData(string $player = null){
         if($player !== null){
 

--- a/src/SalmonDE/StatsPE/Providers/JSONProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/JSONProvider.php
@@ -35,12 +35,9 @@ class JSONProvider implements DataProvider
             }
             $v = $this->dataConfig->getNested(strtolower($player).'.'.$entry->getName());
 
-            if($entry->isValidType($v)){
-                $event = new \SalmonDE\StatsPE\Events\DataReceiveEvent(Base::getInstance(), $v, $player, $entry);
-                Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
-                return $event->getData();
-            }
-            Base::getInstance()->getLogger()->error($msg = 'Unexpected datatype returned "'.gettype($v).'" for entry "'.$entry->getName().'" in "'.self::class.'" by "'.__FUNCTION__.'"!');
+            $event = new \SalmonDE\StatsPE\Events\DataReceiveEvent(Base::getInstance(), $v, $player, $entry);
+            Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
+            return $event->getData();
         }
     }
 

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -246,7 +246,7 @@ class MySQLProvider implements DataProvider
             $this->changes['data'][$playerName][$entryName] = ['value' => $value, 'isIncrement' => $isIncrement];
         }
 
-        if(count(++$this->changes['amount']) > $this->cacheLimit){
+        if(++$this->changes['amount'] > $this->cacheLimit){
             $this->saveAll();
         }
     }

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -11,7 +11,11 @@ class MySQLProvider implements DataProvider
     private $entries = [];
     private $db = null;
 
-    private $changes = [];
+    private $changes = [
+        'amount' => 0,
+        'data' => []
+    ];
+
     private $cacheLimit = 0;
 
     public function __construct($host, $username, $pw, $db, $cacheLimit){
@@ -223,14 +227,14 @@ class MySQLProvider implements DataProvider
         }
     }
 
-    public function incrementValue(string $player, Entry $entry, int $int = 1){
+    public function incrementValue(string $playerName, Entry $entry, int $int = 1){
         if($this->entryExists($entry->getName()) && $entry->shouldSave() && $entry->getExpectedType() === Entry::INT){
 
-            $event = new \SalmonDE\StatsPE\Events\DataSaveEvent(Base::getInstance(), $int, $player, $entry);
+            $event = new \SalmonDE\StatsPE\Events\DataSaveEvent(Base::getInstance(), $int, $playerName, $entry);
             Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
 
             if(!$event->isCancelled()){
-                $this->addChange($playerName, $entry, $value, false);
+                $this->addChange($playerName, $entry, $int, false);
             }
         }
     }
@@ -310,6 +314,7 @@ class MySQLProvider implements DataProvider
     }
 
     private function queryDb(string $query, array $values, bool $multiQuery = false){
+
         $valueTypes = '';
         foreach($values as $value){
             $valueTypes .= is_numeric($value) ? (is_float($value) ? 'd' : 'i') : 's';

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -234,7 +234,7 @@ class MySQLProvider implements DataProvider
             Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
 
             if(!$event->isCancelled()){
-                $this->addChange($playerName, $entry, $int, false);
+                $this->addChange($playerName, $entry, $int, true);
             }
         }
     }
@@ -302,9 +302,9 @@ class MySQLProvider implements DataProvider
         foreach($this->changes['data'] as $playerName => $changedData){
             foreach($changedData as $entryName => $data){
                 if($data['isIncrement']){
-                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.$entryName.' + '.$data['value'].' WHERE Username='.$playerName;
+                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.$entryName.' + '.$data['value'].' WHERE Username='.$playerName.'; ';
                 }else{
-                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.$data['value'].' WHERE Username='.$playerName;
+                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.$data['value'].' WHERE Username='.$playerName.'; ';
                 }
             }
         }

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -315,7 +315,7 @@ class MySQLProvider implements DataProvider
         $this->changes['data'] = [];
     }
 
-    private function queryDb(string $query, array $values){
+    private function queryDb(string $query, array $values){ // reconnecting?
         $valueTypes = '';
         foreach($values as $value){
             $valueTypes .= is_numeric($value) ? (is_float($value) ? 'd' : 'i') : 's';

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -106,7 +106,7 @@ class MySQLProvider implements DataProvider
 
             foreach($wantedEntries as $entry){
                 if($entry->shouldSave()){
-                    $entryList[$entry] = $this->db->real_escape_string($entry->getName());
+                    $entryList[] = $this->db->real_escape_string($entry->getName());
                 }else{
                     $missingEntries[] = $entry->getName();
                 }

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -92,13 +92,9 @@ class MySQLProvider implements DataProvider
 
             $this->applyChanges($playerName, $entry, $value);
 
-            if($entry->isValidType($value)){
-                $event = new \SalmonDE\StatsPE\Events\DataReceiveEvent(Base::getInstance(), $value, $playerName, $entry);
-                Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
-                return $event->getData();
-            }
-
-            Base::getInstance()->getLogger()->error($msg = 'Unexpected datatype returned "'.gettype($value).'" for entry "'.$entry->getName().'" in "'.self::class.'" by "'.__FUNCTION__.'"!');
+            $event = new \SalmonDE\StatsPE\Events\DataReceiveEvent(Base::getInstance(), $value, $playerName, $entry);
+            Base::getInstance()->getServer()->getPluginManager()->callEvent($event);
+            return $event->getData();
         }
     }
 

--- a/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
+++ b/src/SalmonDE/StatsPE/Providers/MySQLProvider.php
@@ -14,8 +14,8 @@ class MySQLProvider implements DataProvider
     private $changes = [];
     private $cacheLimit = 0;
 
-    public function __construct($host, $username, $pw, $db){
-        $this->initialize(['host' => $host, 'username' => $username, 'pw' => $pw, 'db' => $db]);
+    public function __construct($host, $username, $pw, $db, $cacheLimit){
+        $this->initialize(['host' => $host, 'username' => $username, 'pw' => $pw, 'db' => $db, 'cacheLimit' => $cacheLimit]);
     }
 
     public function initialize(array $data){

--- a/src/SalmonDE/StatsPE/Tasks/SaveToDbTask.php
+++ b/src/SalmonDE/StatsPE/Tasks/SaveToDbTask.php
@@ -1,0 +1,62 @@
+<?php
+namespace SalmonDE\StatsPE\Tasks;
+
+use pocketmine\Server;
+
+class SaveToDbTask extends \pocketmine\scheduler\AsyncTask
+{
+
+    private $credentials;
+    private $changes;
+    private $provider;
+
+    public function __construct(array $credentials, array $changes, \SalmonDE\StatsPE\Providers\MySQLProvider $provider){
+        $this->credentials = $credentials;
+        $this->changes = $changes;
+        $this->provider = $provider;
+    }
+
+    public function onRun(){
+        $host = explode(':', $this->credentials['host']);
+        $hostAddress = $host[0];
+        $port = isset($host[1]) ? $host[1] : 3306;
+
+        @$db = new \mysqli($hostAddress, $this->credentials['username'], $this->credentials['password'], $this->credentials['database'], $port);
+
+        $query = '';
+        foreach($this->changes as $playerName => $changedData){
+            foreach($changedData as $entryName => $data){
+                if($data['isIncrement']){
+                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.$entryName.' + '.$data['value'].' WHERE Username='."'".$playerName."'".'; ';
+                }else{
+                    $data['value'] = \SalmonDE\StatsPE\Utils::convertValueSave($this->provider->getEntry($entryName), $data['value']);
+                    $query .= 'UPDATE StatsPE SET '.$entryName.' = '.(is_string($data['value']) ? "'".$db->real_escape_string($data['value'])."'" : $data['value']).' WHERE Username='."'".$playerName."'".'; ';
+                }
+            }
+        }
+
+        $i = 0;
+
+        if($db->multi_query($query)){
+            do{
+                $db->next_result();
+
+                $i++;
+            }while($db->more_results());
+        }
+
+        if($db->errno){
+            $this->setResult('Error: '.$db->error.PHP_EOL.'Query: '.explode(';', $query)[$i]);
+        }
+
+        $db->close();
+    }
+
+    public function onCompletion(Server $server){
+        if($this->getResult() !== null){
+            if(($plugin = $server->getInstance()->getPluginManager()->getPlugin('StatsPE'))->isEnabled()){
+                $plugin->getLogger()->error($this->getResult());
+            }
+        }
+    }
+}


### PR DESCRIPTION
#### **What does the PR do?**
This pr includes optimizations to the mysql data provider, adds a cache limit suggested by @SleepSpace9 in #56 and also adds the method DataProvider::getDataWhere().

#### **Why should this PR be merged?**
It significantly reduces the amount of queries and asynchronously saves cached data to prevent blocking the main thread.

#### **Are the changes in this PR tested**?
<!-- Please test the Pull Request yourself before submitting a pull request. -->
- [x] Yes (Only in testing environment, not in production. Currently testing on production server, giving a day to run.)

#### **Extra Information**
<!-- Anything else we should know? -->
Please squash merge.
